### PR TITLE
Fix error in generating functions

### DIFF
--- a/src/app/app2.tex
+++ b/src/app/app2.tex
@@ -8,8 +8,8 @@
 			\hline \doublerow{Бернулли $\Bernoulli_{p}$}{$p \in (0;1)$} & \doublerow{$\MyPr(\xi=1)=p$}{$\MyPr(\xi=0)=q$} & $p$ & $pq$  & $q+p e^{it}$\\[14pt]
 			\hline \doublerow{Биномиальное $\Binom_{n, p}$}{$p \in (0;1),~ n = 1, 2, \ldots$} & $C_{n}^{k} \, p^{k}(1-p)^{n-k}$ & $np$ & $npq$ & $(q+p e^{i t})^{n}$\\[14pt]
 			\hline \mylinespace[7.5pt] \doublerow{Пуассона $\Pois_{\lambda}$}{$\lambda > 0$} & $\cfrac{\lambda^{k}}{k!}\cdot e^{-\lambda}$ & $\lambda$ & $\lambda$ & $e^{\lambda (e^{i t}-1)}$\\[10pt]
-			\hline \doublerow{Геометрическое $\Geom_{p}$}{$p \in (0;1),~ k = 1, 2, \ldots$} & $p q^{k-1}$ & $\cfrac{1}{p}$ & $\cfrac{q}{p^2}$ & $\cfrac{p}{1-q e^{i t}}$\\[14pt]
-			\hline \mylinespace \doublerow{Отрицательное биномиальное $\NegBinom_{r, p}$}{$p \in (0;1), ~r = 1, 2, \ldots$} & $C_{r-1 + k}^k \, p^r q^{k-1}$ & $\cfrac{r}{p}$ & $\cfrac{rq}{p^2}$ & $\left(\cfrac{p}{1-q e^{i t}}\right)^r$\\[15pt]
+			\hline \doublerow{Геометрическое $\Geom_{p}$}{$p \in (0;1),~ k = 1, 2, \ldots$} & $p q^{k-1}$ & $\cfrac{1}{p}$ & $\cfrac{q}{p^2}$ & $\cfrac{p e^{i t}}{1-q e^{i t}}$\\[14pt]
+			\hline \mylinespace \doublerow{Отрицательное биномиальное $\NegBinom_{r, p}$}{$p \in (0;1), ~r = 1, 2, \ldots$} & $C_{r-1 + k}^k \, p^r q^{k-1}$ & $\cfrac{r}{p e^{i t}}$ & $\cfrac{rq}{p^2}$ & $\left(\cfrac{p}{1-q e^{i t}}\right)^r$\\[15pt]
 			\hline
 		\end{tabular}
 	\end{center}

--- a/src/app/app2.tex
+++ b/src/app/app2.tex
@@ -9,7 +9,7 @@
 			\hline \doublerow{Биномиальное $\Binom_{n, p}$}{$p \in (0;1),~ n = 1, 2, \ldots$} & $C_{n}^{k} \, p^{k}(1-p)^{n-k}$ & $np$ & $npq$ & $(q+p e^{i t})^{n}$\\[14pt]
 			\hline \mylinespace[7.5pt] \doublerow{Пуассона $\Pois_{\lambda}$}{$\lambda > 0$} & $\cfrac{\lambda^{k}}{k!}\cdot e^{-\lambda}$ & $\lambda$ & $\lambda$ & $e^{\lambda (e^{i t}-1)}$\\[10pt]
 			\hline \doublerow{Геометрическое $\Geom_{p}$}{$p \in (0;1),~ k = 1, 2, \ldots$} & $p q^{k-1}$ & $\cfrac{1}{p}$ & $\cfrac{q}{p^2}$ & $\cfrac{p e^{i t}}{1-q e^{i t}}$\\[14pt]
-			\hline \mylinespace \doublerow{Отрицательное биномиальное $\NegBinom_{r, p}$}{$p \in (0;1), ~r = 1, 2, \ldots$} & $C_{r-1 + k}^k \, p^r q^{k-1}$ & $\cfrac{r}{p e^{i t}}$ & $\cfrac{rq}{p^2}$ & $\left(\cfrac{p}{1-q e^{i t}}\right)^r$\\[15pt]
+			\hline \mylinespace \doublerow{Отрицательное биномиальное $\NegBinom_{r, p}$}{$p \in (0;1), ~r = 1, 2, \ldots$} & $C_{k-1}^{r-1} \, p^r q^{k-r}$ & $\cfrac{r}{p}$ & $\cfrac{rq}{p^2}$ & $\left(\cfrac{p e^{i t}}{1-q e^{i t}}\right)^r$\\[15pt]
 			\hline
 		\end{tabular}
 	\end{center}


### PR DESCRIPTION
Существует некоторая путаница в определении геометрического распределения. Пусть $\xi \sim \mathrm{Geom}(p)$. В некоторых источниках $\xi = k$ означает, что первый успех в испытании Бернулли наступил на $k$-м шаге, в других же -- что первому успеху предшествовало $k$ неудач, а сам он случился на шаге $k+1$. Это два разных распределения, которые отличаются друг от друга на единицу; их также обозначают $\mathrm {Geom}_1$ и $\mathrm{Geom}_0$ соответственно. В таблице указано, что параметр $k$ принадлежит натуральным числам, что соответствует $\mathrm {Geom}_1$, и распределение и моментные характеристики указаны корректно, а вот характеристическая функция записана для $\mathrm {Geom}_0$. 
То же справедливо для отрицательного биномиального распределения, которое можно трактовать либо как сумму $r$ 1-геометрических, либо 0-геометрических случайных величин. Два варианта $\mathrm{NB}$-распределения отличаются друг от друга на константу $r$.
В пулл-реквесте исправлены харфункции для этих двух распределений.

UPD ещё исправил распределение NB, оно тоже неверное было